### PR TITLE
feat: state `present-auto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ N/A
 
 | **Variable Name**      | **Type**| **Default Value**| **Description**|
 | :----------------------| :------:| :---------------:| :--------------|
-| qemu_guest_agent_state:| string  | "detect"         | This variable can be one of the following states `"absent"`, `"detect"`, `"latest"`, `"present"`. When `"absent"` the qemu-guest-agent package will be removed. When `"detect"` the package will be installed if the host has the virtual device required by the qemu-guest-agent, if the virtual device is absent the package will be removed. When `"latest"` the package will be installed or updated to the latest version. When `"present"` the package will be installed.|
+| qemu_guest_agent_state:| string  | "present-auto"   | Defines the installation state of qemu-guest-agent. Possible values:<br> `"present"` – Ensures the package is installed.<br> `"present-auto"` - Installs the package only if the host has the required virtual device; it remains installed even if the device is later removed.<br> `"auto"` – Installs the package if the required virtual device is present; removes it if the device is absent.<br> `"latest"` – Installs or updates the package to the latest version.<br> `"absent"` – Ensures the package is removed.|
 
 ## Example Playbooks
 
@@ -19,7 +19,7 @@ N/A
   roles:
     - role: tinyblargon.qemu_guest_agent
       vars:
-        qemu_guest_agent_state: "present"
+        qemu_guest_agent_state: "present-auto"
 ```
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-qemu_guest_agent_state: 'detect'
+qemu_guest_agent_state: "present-auto"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: Check if guest agent is availible
+- name: Check if guest agent is available
   ansible.builtin.stat:
     path: "/dev/virtio-ports"
   register: qemu_guest_agent_device
-  when: qemu_guest_agent_state == "detect"
+  when: qemu_guest_agent_state in ["auto", "detect", "present-auto"]
 
 - name: Ensure qemu-guest-agent is installed
   ansible.builtin.apt:
@@ -37,4 +37,5 @@
   when: >-
     qemu_guest_agent_state == "absent" or
     (qemu_guest_agent_device.stat.exists is defined
-    and qemu_guest_agent_device.stat.exists is false)
+    and qemu_guest_agent_device.stat.exists is false
+    and qemu_guest_agent_state in ["auto", "detect"])


### PR DESCRIPTION

- Add the `present-auto` state option.
- Deprecate the `detect` option in favor of `auto`.
- Set `present-auto` as default state option, no auto removal by default.